### PR TITLE
Feature/migration commons configuration2 0.9.0 20170605

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 #jBB - Java Bulletin Board
 =================================
-[![Build Status](http://vps289371.ovh.net:8000/buildStatus/icon?job=jBB-build-develop)](http://vps289371.ovh.net:8000/job/jBB-build-develop/) 
-[![Quality Gate](http://vps289371.ovh.net:9000/api/badges/gate?key=org.jbb:jbb-parent:DEV-SNAPSHOT)](http://vps289371.ovh.net:9000/dashboard?id=org.jbb%3Ajbb-parent%3ADEV-SNAPSHOT)
-[![Overall coverage](http://vps289371.ovh.net:9000/api/badges/measure?key=org.jbb:jbb-parent:DEV-SNAPSHOT&metric=coverage&blinking=true)](http://vps289371.ovh.net:9000/dashboard?id=org.jbb%3Ajbb-parent%3ADEV-SNAPSHOT) 
-[![Blocker violations](http://vps289371.ovh.net:9000/api/badges/measure?key=org.jbb:jbb-parent:DEV-SNAPSHOT&metric=blocker_violations&blinking=true)](http://vps289371.ovh.net:9000/dashboard?id=org.jbb%3Ajbb-parent%3ADEV-SNAPSHOT) 
-[![Critical violations](http://vps289371.ovh.net:9000/api/badges/measure?key=org.jbb:jbb-parent:DEV-SNAPSHOT&metric=critical_violations&blinking=true)](http://vps289371.ovh.net:9000/dashboard?id=org.jbb%3Ajbb-parent%3ADEV-SNAPSHOT) 
-[![Bugs](http://vps289371.ovh.net:9000/api/badges/measure?key=org.jbb:jbb-parent:DEV-SNAPSHOT&metric=bugs&blinking=true)](http://vps289371.ovh.net:9000/dashboard?id=org.jbb%3Ajbb-parent%3ADEV-SNAPSHOT) 
-[![Vulnerabilities](http://vps289371.ovh.net:9000/api/badges/measure?key=org.jbb:jbb-parent:DEV-SNAPSHOT&metric=vulnerabilities&blinking=true)](http://vps289371.ovh.net:9000/dashboard?id=org.jbb%3Ajbb-parent%3ADEV-SNAPSHOT)
+[![Build Status](http://vps289371.ovh.net:8000/buildStatus/icon?job=jBB-build-feature_commons-configuration2_0.9.0_20170605)](http://vps289371.ovh.net:8000/job/jBB-build-feature_commons-configuration2_0.9.0_20170605/) 
+[![Quality Gate](http://vps289371.ovh.net:9000/api/badges/gate?key=org.jbb:jbb-parent:0.9.0-commons-configuration2-SNAPSHOT)](http://vps289371.ovh.net:9000/dashboard?id=org.jbb%3Ajbb-parent%3A0.9.0-commons-configuration2-SNAPSHOT)
+[![Overall coverage](http://vps289371.ovh.net:9000/api/badges/measure?key=org.jbb:jbb-parent:0.9.0-commons-configuration2-SNAPSHOT&metric=coverage&blinking=true)](http://vps289371.ovh.net:9000/dashboard?id=org.jbb%3Ajbb-parent%3A0.9.0-commons-configuration2-SNAPSHOT) 
+[![Blocker violations](http://vps289371.ovh.net:9000/api/badges/measure?key=org.jbb:jbb-parent:0.9.0-commons-configuration2-SNAPSHOT&metric=blocker_violations&blinking=true)](http://vps289371.ovh.net:9000/dashboard?id=org.jbb%3Ajbb-parent%3A0.9.0-commons-configuration2-SNAPSHOT) 
+[![Critical violations](http://vps289371.ovh.net:9000/api/badges/measure?key=org.jbb:jbb-parent:0.9.0-commons-configuration2-SNAPSHOT&metric=critical_violations&blinking=true)](http://vps289371.ovh.net:9000/dashboard?id=org.jbb%3Ajbb-parent%3A0.9.0-commons-configuration2-SNAPSHOT) 
+[![Bugs](http://vps289371.ovh.net:9000/api/badges/measure?key=org.jbb:jbb-parent:0.9.0-commons-configuration2-SNAPSHOT&metric=bugs&blinking=true)](http://vps289371.ovh.net:9000/dashboard?id=org.jbb%3Ajbb-parent%3A0.9.0-commons-configuration2-SNAPSHOT) 
+[![Vulnerabilities](http://vps289371.ovh.net:9000/api/badges/measure?key=org.jbb:jbb-parent:0.9.0-commons-configuration2-SNAPSHOT&metric=vulnerabilities&blinking=true)](http://vps289371.ovh.net:9000/dashboard?id=org.jbb%3Ajbb-parent%3A0.9.0-commons-configuration2-SNAPSHOT)
 
 
 jBB is free and open source board bulletin software written with java.

--- a/domain-api/jbb-board-api/pom.xml
+++ b/domain-api/jbb-board-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-api</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-board-api</artifactId>

--- a/domain-api/jbb-event-registry/pom.xml
+++ b/domain-api/jbb-event-registry/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-api</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-event-registry</artifactId>

--- a/domain-api/jbb-frontend-api/pom.xml
+++ b/domain-api/jbb-frontend-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-api</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-frontend-api</artifactId>

--- a/domain-api/jbb-members-api/pom.xml
+++ b/domain-api/jbb-members-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-api</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-members-api</artifactId>

--- a/domain-api/jbb-security-api/pom.xml
+++ b/domain-api/jbb-security-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-api</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-security-api</artifactId>

--- a/domain-api/jbb-system-api/pom.xml
+++ b/domain-api/jbb-system-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-api</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-system-api</artifactId>

--- a/domain-api/pom.xml
+++ b/domain-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb</groupId>
         <artifactId>jbb-parent</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jbb.domain</groupId>

--- a/domain-services/jbb-board/pom.xml
+++ b/domain-services/jbb-board/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-services</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-board</artifactId>

--- a/domain-services/jbb-board/src/main/java/org/jbb/board/impl/base/data/validation/ValidDateFormatValidator.java
+++ b/domain-services/jbb-board/src/main/java/org/jbb/board/impl/base/data/validation/ValidDateFormatValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 the original author or authors.
+ * Copyright (C) 2017 the original author or authors.
  *
  * This file is part of jBB Application Project.
  *
@@ -10,7 +10,8 @@
 
 package org.jbb.board.impl.base.data.validation;
 
-import org.apache.commons.lang.Validate;
+
+import org.apache.commons.lang3.Validate;
 
 import java.time.format.DateTimeFormatter;
 

--- a/domain-services/jbb-board/src/main/java/org/jbb/board/impl/base/logic/BoardSettingsServiceImpl.java
+++ b/domain-services/jbb-board/src/main/java/org/jbb/board/impl/base/logic/BoardSettingsServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 the original author or authors.
+ * Copyright (C) 2017 the original author or authors.
  *
  * This file is part of jBB Application Project.
  *
@@ -10,7 +10,7 @@
 
 package org.jbb.board.impl.base.logic;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.jbb.board.api.base.BoardException;
 import org.jbb.board.api.base.BoardSettings;
 import org.jbb.board.api.base.BoardSettingsService;

--- a/domain-services/jbb-frontend/pom.xml
+++ b/domain-services/jbb-frontend/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-services</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-frontend</artifactId>

--- a/domain-services/jbb-members/pom.xml
+++ b/domain-services/jbb-members/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-services</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-members</artifactId>

--- a/domain-services/jbb-security/pom.xml
+++ b/domain-services/jbb-security/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-services</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-security</artifactId>

--- a/domain-services/jbb-system/pom.xml
+++ b/domain-services/jbb-system/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-services</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-system</artifactId>

--- a/domain-services/jbb-system/src/main/java/org/jbb/system/impl/logging/logic/AppenderBrowser.java
+++ b/domain-services/jbb-system/src/main/java/org/jbb/system/impl/logging/logic/AppenderBrowser.java
@@ -10,7 +10,7 @@
 
 package org.jbb.system.impl.logging.logic;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.jbb.system.api.logging.model.LogAppender;
 import org.jbb.system.api.logging.model.LogConsoleAppender;

--- a/domain-services/jbb-system/src/main/java/org/jbb/system/impl/logging/logic/LoggerBrowser.java
+++ b/domain-services/jbb-system/src/main/java/org/jbb/system/impl/logging/logic/LoggerBrowser.java
@@ -10,7 +10,7 @@
 
 package org.jbb.system.impl.logging.logic;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.jbb.system.api.logging.model.AppLogger;
 import org.jbb.system.api.logging.model.LoggingConfiguration;

--- a/domain-services/pom.xml
+++ b/domain-services/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb</groupId>
         <artifactId>jbb-parent</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jbb.domain</groupId>

--- a/domain-web/jbb-board-web/pom.xml
+++ b/domain-web/jbb-board-web/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-web</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-board-web</artifactId>

--- a/domain-web/jbb-frontend-web/pom.xml
+++ b/domain-web/jbb-frontend-web/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-web</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-frontend-web</artifactId>

--- a/domain-web/jbb-members-web/pom.xml
+++ b/domain-web/jbb-members-web/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-web</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-members-web</artifactId>

--- a/domain-web/jbb-security-web/pom.xml
+++ b/domain-web/jbb-security-web/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-web</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-security-web</artifactId>

--- a/domain-web/jbb-system-web/pom.xml
+++ b/domain-web/jbb-system-web/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.domain</groupId>
         <artifactId>domain-web</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-system-web</artifactId>

--- a/domain-web/pom.xml
+++ b/domain-web/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb</groupId>
         <artifactId>jbb-parent</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jbb.domain</groupId>

--- a/jbb-bom/pom.xml
+++ b/jbb-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jbb</groupId>
     <artifactId>jbb-bom</artifactId>
-    <version>DEV-SNAPSHOT</version>
+    <version>0.9.0-commons-configuration2-SNAPSHOT</version>
 
 
     <packaging>pom</packaging>

--- a/jbb-bom/pom.xml
+++ b/jbb-bom/pom.xml
@@ -28,6 +28,7 @@
         <commons.lang3.version>3.5</commons.lang3.version>
         <lombok.version>1.16.16</lombok.version>
         <commons.io.version>2.5</commons.io.version>
+        <commons.beanutils.version>1.9.3</commons.beanutils.version>
         <reflections.version>0.9.10</reflections.version> <!--BEWARE !!! -->
         <aspectj.version>1.8.10</aspectj.version>
         <findbugs.annotations.version>3.0.1</findbugs.annotations.version>
@@ -86,7 +87,7 @@
 
         <!-- PROPERTY MANAGEMENT -->
         <owner.version>1.0.9</owner.version>
-        <commons.configuration.version>1.10</commons.configuration.version>
+        <commons.configuration2.version>2.1.1</commons.configuration2.version>
 
         <!-- MONITORING -->
         <javamelody.core.version>1.67.0</javamelody.core.version>
@@ -157,6 +158,12 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons.io.version}</version>
+            </dependency>
+            <dependency>
+                <!-- this is required dependency on runtime for commons-configuration2 -->
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>${commons.beanutils.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.reflections</groupId>
@@ -714,9 +721,9 @@
                 <version>${owner.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-configuration</groupId>
-                <artifactId>commons-configuration</artifactId>
-                <version>${commons.configuration.version}</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>${commons.configuration2.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>

--- a/jbb-build-tools/pom.xml
+++ b/jbb-build-tools/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jbb</groupId>
     <artifactId>jbb-build-tools</artifactId>
-    <version>DEV-SNAPSHOT</version>
+    <version>0.9.0-commons-configuration2-SNAPSHOT</version>
 
     <name>jBB Build Tools</name>
     <description>Custom configurations for maven plugins executed during jBB build</description>

--- a/jbb-web-app-e2e-tests/pom.xml
+++ b/jbb-web-app-e2e-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb</groupId>
         <artifactId>jbb-parent</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jbb.qa</groupId>

--- a/jbb-web-app-load-tests/pom.xml
+++ b/jbb-web-app-load-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb</groupId>
         <artifactId>jbb-parent</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jbb.qa</groupId>

--- a/jbb-web-app/pom.xml
+++ b/jbb-web-app/pom.xml
@@ -124,7 +124,7 @@
                                 </goals>
                                 <configuration>
                                     <source>
-                                        import org.apache.commons.lang.StringUtils
+                                        import org.apache.commons.lang3.StringUtils
 
                                         project.properties["version.to.lower.case"] = StringUtils.lowerCase(project.getVersion())
                                     </source>

--- a/jbb-web-app/pom.xml
+++ b/jbb-web-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb</groupId>
         <artifactId>jbb-parent</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jbb.dist</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jbb</groupId>
     <artifactId>jbb-parent</artifactId>
-    <version>DEV-SNAPSHOT</version>
+    <version>0.9.0-commons-configuration2-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/tech-services/jbb-lib-cache/pom.xml
+++ b/tech-services/jbb-lib-cache/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.lib</groupId>
         <artifactId>tech-services</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-lib-cache</artifactId>

--- a/tech-services/jbb-lib-commons/pom.xml
+++ b/tech-services/jbb-lib-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.lib</groupId>
         <artifactId>tech-services</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-lib-commons</artifactId>

--- a/tech-services/jbb-lib-commons/pom.xml
+++ b/tech-services/jbb-lib-commons/pom.xml
@@ -17,8 +17,13 @@
     <dependencies>
         <!-- EXTERNAL DEPENDENCIES -->
         <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+        </dependency>
+        <dependency>
+            <!-- this is required dependency on runtime for commons-configuration2 -->
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/tech-services/jbb-lib-commons/src/main/java/org/jbb/lib/commons/JbbMetaData.java
+++ b/tech-services/jbb-lib-commons/src/main/java/org/jbb/lib/commons/JbbMetaData.java
@@ -10,12 +10,16 @@
 
 package org.jbb.lib.commons;
 
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.springframework.core.io.ClassPathResource;
 
 import java.io.IOException;
+import java.net.URL;
 
 public class JbbMetaData {
     private static final String MANIFEST_FILENAME = "manifest.data";
@@ -34,10 +38,20 @@ public class JbbMetaData {
 
     private void bindFileToConfiguration(ClassPathResource manifestDataFile) {
         try {
-            data = new PropertiesConfiguration(manifestDataFile.getURL());
+            data = buildPropertiesConfiguration(manifestDataFile.getURL());
         } catch (ConfigurationException | IOException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    private Configuration buildPropertiesConfiguration(URL url) throws ConfigurationException {
+        FileBasedConfigurationBuilder<PropertiesConfiguration> builder =
+                new FileBasedConfigurationBuilder<>(PropertiesConfiguration.class)
+                        .configure(new Parameters().properties()
+                                .setURL(url)
+                                .setThrowExceptionOnMissing(true)
+                                .setIncludesAllowed(false));
+        return builder.getConfiguration();
     }
 
     public String jbbVersion() {

--- a/tech-services/jbb-lib-db-tier/pom.xml
+++ b/tech-services/jbb-lib-db-tier/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.lib</groupId>
         <artifactId>tech-services</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-lib-db-tier</artifactId>

--- a/tech-services/jbb-lib-db-tier/src/main/java/org/jbb/lib/db/EmbeddedDatabaseServerManager.java
+++ b/tech-services/jbb-lib-db-tier/src/main/java/org/jbb/lib/db/EmbeddedDatabaseServerManager.java
@@ -10,7 +10,7 @@
 
 package org.jbb.lib.db;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.h2.tools.Server;
 import org.jbb.lib.commons.H2Settings;
 import org.springframework.beans.factory.InitializingBean;

--- a/tech-services/jbb-lib-eventbus/pom.xml
+++ b/tech-services/jbb-lib-eventbus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.lib</groupId>
         <artifactId>tech-services</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-lib-eventbus</artifactId>

--- a/tech-services/jbb-lib-logging/pom.xml
+++ b/tech-services/jbb-lib-logging/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.lib</groupId>
         <artifactId>tech-services</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-lib-logging</artifactId>

--- a/tech-services/jbb-lib-logging/src/main/java/org/jbb/lib/logging/CachingAppender.java
+++ b/tech-services/jbb-lib-logging/src/main/java/org/jbb/lib/logging/CachingAppender.java
@@ -10,7 +10,7 @@
 
 package org.jbb.lib.logging;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 

--- a/tech-services/jbb-lib-mvc/pom.xml
+++ b/tech-services/jbb-lib-mvc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.lib</groupId>
         <artifactId>tech-services</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-lib-mvc</artifactId>

--- a/tech-services/jbb-lib-mvc/src/main/java/org/jbb/lib/mvc/formatters/DurationFormatter.java
+++ b/tech-services/jbb-lib-mvc/src/main/java/org/jbb/lib/mvc/formatters/DurationFormatter.java
@@ -10,8 +10,8 @@
 
 package org.jbb.lib.mvc.formatters;
 
-import org.apache.commons.lang.time.DurationFormatUtils;
 import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.jbb.lib.mvc.properties.MvcProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.Formatter;

--- a/tech-services/jbb-lib-properties/pom.xml
+++ b/tech-services/jbb-lib-properties/pom.xml
@@ -34,8 +34,13 @@
             <artifactId>owner</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+        </dependency>
+        <dependency>
+            <!-- this is required dependency on runtime for commons-configuration2 -->
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/tech-services/jbb-lib-properties/pom.xml
+++ b/tech-services/jbb-lib-properties/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.lib</groupId>
         <artifactId>tech-services</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-lib-properties</artifactId>

--- a/tech-services/jbb-lib-properties/src/main/java/org/jbb/lib/properties/FreshInstallPropertiesCreator.java
+++ b/tech-services/jbb-lib-properties/src/main/java/org/jbb/lib/properties/FreshInstallPropertiesCreator.java
@@ -12,10 +12,12 @@ package org.jbb.lib.properties;
 
 import com.google.common.collect.Lists;
 
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.springframework.core.io.ClassPathResource;
 
 import java.io.File;
@@ -53,7 +55,13 @@ class FreshInstallPropertiesCreator {
     private static PropertiesConfiguration getReferenceProperties(File propertyFile) {
         try {
             ClassPathResource classPathResource = new ClassPathResource(propertyFile.getName());
-            return new PropertiesConfiguration(classPathResource.getURL());
+            FileBasedConfigurationBuilder<PropertiesConfiguration> builder =
+                    new FileBasedConfigurationBuilder<>(PropertiesConfiguration.class)
+                            .configure(new Parameters().properties()
+                                    .setURL(classPathResource.getURL())
+                                    .setThrowExceptionOnMissing(true)
+                                    .setIncludesAllowed(false));
+            return builder.getConfiguration();
         } catch (ConfigurationException | IOException e) {
             throw new IllegalStateException(e);
         }
@@ -61,9 +69,13 @@ class FreshInstallPropertiesCreator {
 
     private static PropertiesConfiguration getTargetPropertiesFromJbbPath(File propertyFile) {
         try {
-            PropertiesConfiguration targetPropertiesConfig = new PropertiesConfiguration(propertyFile);
-            targetPropertiesConfig.setAutoSave(true);
-            return targetPropertiesConfig;
+            FileBasedConfigurationBuilder<PropertiesConfiguration> builder =
+                    new FileBasedConfigurationBuilder<>(PropertiesConfiguration.class)
+                            .configure(new Parameters().properties()
+                                    .setFile(propertyFile)
+                                    .setIncludesAllowed(false));
+            builder.setAutoSave(true);
+            return builder.getConfiguration();
         } catch (ConfigurationException e) {
             throw new IllegalStateException(e);
         }

--- a/tech-services/jbb-lib-properties/src/main/java/org/jbb/lib/properties/JbbPropertyFilesResolver.java
+++ b/tech-services/jbb-lib-properties/src/main/java/org/jbb/lib/properties/JbbPropertyFilesResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 the original author or authors.
+ * Copyright (C) 2017 the original author or authors.
  *
  * This file is part of jBB Application Project.
  *
@@ -13,7 +13,7 @@ package org.jbb.lib.properties;
 import com.google.common.collect.Sets;
 
 import org.aeonbits.owner.Config;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.jbb.lib.commons.JbbMetaData;
 
 import java.util.Set;

--- a/tech-services/jbb-lib-properties/src/main/java/org/jbb/lib/properties/SafeBlankPropertyAspect.java
+++ b/tech-services/jbb-lib-properties/src/main/java/org/jbb/lib/properties/SafeBlankPropertyAspect.java
@@ -11,7 +11,7 @@
 package org.jbb.lib.properties;
 
 import org.aeonbits.owner.Config;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;

--- a/tech-services/jbb-lib-properties/src/main/java/org/jbb/lib/properties/UpdateFilePropertyChangeListener.java
+++ b/tech-services/jbb-lib-properties/src/main/java/org/jbb/lib/properties/UpdateFilePropertyChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 the original author or authors.
+ * Copyright (C) 2017 the original author or authors.
  *
  * This file is part of jBB Application Project.
  *
@@ -11,8 +11,10 @@
 package org.jbb.lib.properties;
 
 
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -30,9 +32,14 @@ class UpdateFilePropertyChangeListener implements PropertyChangeListener {
     public void propertyChange(PropertyChangeEvent evt) {
         for (String propertyFile : propFiles) {
             try {
-                PropertiesConfiguration conf = new PropertiesConfiguration(propertyFile);
-                conf.setAutoSave(true);
-                evt.setPropagationId(conf.getFile().getName());
+                FileBasedConfigurationBuilder<PropertiesConfiguration> builder =
+                        new FileBasedConfigurationBuilder<>(PropertiesConfiguration.class)
+                                .configure(new Parameters().properties()
+                                        .setFileName(propertyFile)
+                                        .setIncludesAllowed(false));
+                builder.setAutoSave(true);
+                PropertiesConfiguration conf = builder.getConfiguration();
+                evt.setPropagationId(propertyFile);
                 conf.setProperty(evt.getPropertyName(), evt.getNewValue());
             } catch (ConfigurationException e) {
                 throw new IllegalArgumentException(e);

--- a/tech-services/jbb-lib-properties/src/main/java/org/jbb/lib/properties/encrypt/EncryptionPlaceholderUtils.java
+++ b/tech-services/jbb-lib-properties/src/main/java/org/jbb/lib/properties/encrypt/EncryptionPlaceholderUtils.java
@@ -10,7 +10,8 @@
 
 package org.jbb.lib.properties.encrypt;
 
-import static org.apache.commons.lang.StringUtils.substringBetween;
+
+import static org.apache.commons.lang3.StringUtils.substringBetween;
 
 public final class EncryptionPlaceholderUtils {
     private EncryptionPlaceholderUtils() {

--- a/tech-services/jbb-lib-properties/src/test/java/org/jbb/lib/properties/FreshInstallPropertiesCreatorTest.java
+++ b/tech-services/jbb-lib-properties/src/test/java/org/jbb/lib/properties/FreshInstallPropertiesCreatorTest.java
@@ -40,8 +40,8 @@ public class FreshInstallPropertiesCreatorTest {
     @InjectMocks
     private FreshInstallPropertiesCreator propertiesCreator;
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowIAE_whenNullPassed() throws Exception {
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNPE_whenNullPassed() throws Exception {
         // given
         Class<? extends ModuleProperties> nullClass = null;
 
@@ -49,7 +49,7 @@ public class FreshInstallPropertiesCreatorTest {
         propertiesCreator.putDefaultPropertiesIfNeeded(nullClass);
 
         // then
-        // throw IllegalArgumentException
+        // throw NullPointerException
     }
 
     @Test

--- a/tech-services/jbb-lib-properties/src/test/java/org/jbb/lib/properties/JbbPropertyFilesResolverTest.java
+++ b/tech-services/jbb-lib-properties/src/test/java/org/jbb/lib/properties/JbbPropertyFilesResolverTest.java
@@ -37,8 +37,8 @@ public class JbbPropertyFilesResolverTest {
         assertThat(propertyFilesResolver).isNotNull();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowIAE_whenNullPassed() throws Exception {
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNPE_whenNullPassed() throws Exception {
         // given
         Class<? extends ModuleProperties> nullClass = null;
 
@@ -46,7 +46,7 @@ public class JbbPropertyFilesResolverTest {
         propertyFilesResolver.resolvePropertyFileNames(nullClass);
 
         // then
-        // throw IllegalArgumentException
+        // throw NullPointerException
     }
 
 

--- a/tech-services/jbb-lib-properties/src/test/java/org/jbb/lib/properties/UpdateFilePropertyChangeListenerTest.java
+++ b/tech-services/jbb-lib-properties/src/test/java/org/jbb/lib/properties/UpdateFilePropertyChangeListenerTest.java
@@ -11,7 +11,7 @@
 package org.jbb.lib.properties;
 
 import org.aeonbits.owner.Config;
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.jbb.lib.commons.JbbMetaData;
 import org.junit.Before;

--- a/tech-services/jbb-lib-properties/src/test/java/org/jbb/lib/properties/encrypt/EncryptionPlaceholderUtilsTest.java
+++ b/tech-services/jbb-lib-properties/src/test/java/org/jbb/lib/properties/encrypt/EncryptionPlaceholderUtilsTest.java
@@ -10,7 +10,7 @@
 
 package org.jbb.lib.properties.encrypt;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tech-services/jbb-lib-properties/src/test/java/org/jbb/lib/properties/encrypt/PropertiesEncryptionIT.java
+++ b/tech-services/jbb-lib-properties/src/test/java/org/jbb/lib/properties/encrypt/PropertiesEncryptionIT.java
@@ -10,8 +10,10 @@
 
 package org.jbb.lib.properties.encrypt;
 
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.jbb.lib.commons.CommonsConfig;
 import org.jbb.lib.commons.JbbMetaData;
 import org.jbb.lib.properties.PropertiesConfig;
@@ -84,6 +86,12 @@ public class PropertiesEncryptionIT {
 
     private void readPropertiesFile() throws ConfigurationException {
         String propertiesFilePath = jbbMetaData.jbbHomePath() + File.separator + "jbb-testbed.properties";
-        propFile = new PropertiesConfiguration(propertiesFilePath);
+        FileBasedConfigurationBuilder<PropertiesConfiguration> builder =
+                new FileBasedConfigurationBuilder<>(PropertiesConfiguration.class)
+                        .configure(new Parameters().properties()
+                                .setPath(propertiesFilePath)
+                                .setIncludesAllowed(false));
+        builder.setAutoSave(true);
+        propFile = builder.getConfiguration();
     }
 }

--- a/tech-services/jbb-lib-test/pom.xml
+++ b/tech-services/jbb-lib-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb.lib</groupId>
         <artifactId>tech-services</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbb-lib-test</artifactId>

--- a/tech-services/pom.xml
+++ b/tech-services/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jbb</groupId>
         <artifactId>jbb-parent</artifactId>
-        <version>DEV-SNAPSHOT</version>
+        <version>0.9.0-commons-configuration2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jbb.lib</groupId>


### PR DESCRIPTION
Upgrade from legacy Apache Commons-configuration 1.x library to 2.1.1: https://commons.apache.org/proper/commons-configuration/userguide/upgradeto2_0.html

Remove usage of old API org.apache.commons.lang.*. After merge only lang3 API will be used.